### PR TITLE
properties.Map now keeps the insertion ordering

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -36,7 +36,7 @@ import (
 // GetBoolean returns true if the map contains the specified key and the value
 // equals to the string "true", in any other case returns false.
 func (m Map) GetBoolean(key string) bool {
-	value, ok := m[key]
+	value, ok := m.GetOk(key)
 	return ok && value == "true"
 }
 
@@ -44,16 +44,16 @@ func (m Map) GetBoolean(key string) bool {
 // is respectively true or false.
 func (m Map) SetBoolean(key string, value bool) {
 	if value {
-		m[key] = "true"
+		m.Set(key, "true")
 	} else {
-		m[key] = "false"
+		m.Set(key, "false")
 	}
 }
 
 // GetPath returns a paths.Path object using the map value as path. The function
 // returns nil if the key is not present.
 func (m Map) GetPath(key string) *paths.Path {
-	value, ok := m[key]
+	value, ok := m.GetOk(key)
 	if !ok {
 		return nil
 	}
@@ -63,8 +63,8 @@ func (m Map) GetPath(key string) *paths.Path {
 // SetPath saves the paths.Path object in the map using the path as value of the map
 func (m Map) SetPath(key string, value *paths.Path) {
 	if value == nil {
-		m[key] = ""
+		m.Set(key, "")
 	} else {
-		m[key] = value.String()
+		m.Set(key, value.String())
 	}
 }

--- a/properties.go
+++ b/properties.go
@@ -56,6 +56,9 @@ syntax, for example:
 
 This library has methods to parse this kind of files into a Map object.
 
+The Map internally keeps the insertion order so it can be retrieved later when
+cycling through the key sets.
+
 The Map object has many helper methods to accomplish some common operation
 on this kind of data like cloning, merging, comparing and also extracting
 a submap or generating a map-of-submaps from the first "level" of the hierarchy.
@@ -72,14 +75,16 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"sort"
 	"strings"
 
 	"github.com/arduino/go-paths-helper"
 )
 
 // Map is a container of properties
-type Map map[string]string
+type Map struct {
+	kv map[string]string
+	o  []string
+}
 
 var osSuffix string
 
@@ -94,8 +99,16 @@ func init() {
 	}
 }
 
+// New returns a new Map
+func New() *Map {
+	return &Map{
+		kv: map[string]string{},
+		o:  []string{},
+	}
+}
+
 // Load reads a properties file and makes a Map out of it.
-func Load(filepath string) (Map, error) {
+func Load(filepath string) (*Map, error) {
 	bytes, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading file: %s", err)
@@ -105,7 +118,7 @@ func Load(filepath string) (Map, error) {
 	text = strings.Replace(text, "\r\n", "\n", -1)
 	text = strings.Replace(text, "\r", "\n", -1)
 
-	properties := make(Map)
+	properties := New()
 
 	for lineNum, line := range strings.Split(text, "\n") {
 		if err := properties.parseLine(line); err != nil {
@@ -117,14 +130,14 @@ func Load(filepath string) (Map, error) {
 }
 
 // LoadFromPath reads a properties file and makes a Map out of it.
-func LoadFromPath(path *paths.Path) (Map, error) {
+func LoadFromPath(path *paths.Path) (*Map, error) {
 	return Load(path.String())
 }
 
 // LoadFromSlice reads a properties file from an array of string
 // and makes a Map out of it
-func LoadFromSlice(lines []string) (Map, error) {
-	properties := make(Map)
+func LoadFromSlice(lines []string) (*Map, error) {
+	properties := New()
 
 	for lineNum, line := range lines {
 		if err := properties.parseLine(line); err != nil {
@@ -135,7 +148,7 @@ func LoadFromSlice(lines []string) (Map, error) {
 	return properties, nil
 }
 
-func (m Map) parseLine(line string) error {
+func (m *Map) parseLine(line string) error {
 	line = strings.TrimSpace(line)
 
 	// Skip empty lines or comments
@@ -151,23 +164,23 @@ func (m Map) parseLine(line string) error {
 	value := strings.TrimSpace(lineParts[1])
 
 	key = strings.Replace(key, "."+osSuffix, "", 1)
-	m[key] = value
+	m.Set(key, value)
 
 	return nil
 }
 
 // SafeLoadFromPath is like LoadFromPath, except that it returns an empty Map if
 // the specified file doesn't exists
-func SafeLoadFromPath(path *paths.Path) (Map, error) {
+func SafeLoadFromPath(path *paths.Path) (*Map, error) {
 	return SafeLoad(path.String())
 }
 
 // SafeLoad is like Load, except that it returns an empty Map if the specified
 // file doesn't exists
-func SafeLoad(filepath string) (Map, error) {
+func SafeLoad(filepath string) (*Map, error) {
 	_, err := os.Stat(filepath)
 	if os.IsNotExist(err) {
-		return make(Map), nil
+		return New(), nil
 	}
 
 	properties, err := Load(filepath)
@@ -175,6 +188,49 @@ func SafeLoad(filepath string) (Map, error) {
 		return nil, err
 	}
 	return properties, nil
+}
+
+// Get retrieve the value corresponding to key
+func (m *Map) Get(key string) string {
+	return m.kv[key]
+}
+
+// GetOk retrieve the value corresponding to key and return a true/false indicator
+// to check if the key is present in the map (true if the key is present)
+func (m *Map) GetOk(key string) (string, bool) {
+	v, ok := m.kv[key]
+	return v, ok
+}
+
+// ContainsKey returns true
+func (m *Map) ContainsKey(key string) bool {
+	_, has := m.kv[key]
+	return has
+}
+
+// Set inserts or replaces an existing key-value pair in the map
+func (m *Map) Set(key, value string) {
+	if _, has := m.kv[key]; has {
+		m.Remove(key)
+	}
+	m.kv[key] = value
+	m.o = append(m.o, key)
+}
+
+// Size return the number of elements in the map
+func (m *Map) Size() int {
+	return len(m.kv)
+}
+
+// Remove removes the key from the map
+func (m *Map) Remove(key string) {
+	delete(m.kv, key)
+	for i, k := range m.o {
+		if k == key {
+			m.o = append(m.o[:i], m.o[i+1:]...)
+			return
+		}
+	}
 }
 
 // FirstLevelOf generates a map-of-Maps using the first level of the hierarchy
@@ -209,17 +265,18 @@ func SafeLoad(filepath string) (Map, error) {
 //      "bootloader.low_fuses": "0xFF",
 //    }
 //  }
-func (m Map) FirstLevelOf() map[string]Map {
-	newMap := make(map[string]Map)
-	for key, value := range m {
+func (m *Map) FirstLevelOf() map[string]*Map {
+	newMap := make(map[string]*Map)
+	for _, key := range m.o {
 		if strings.Index(key, ".") == -1 {
 			continue
 		}
 		keyParts := strings.SplitN(key, ".", 2)
 		if newMap[keyParts[0]] == nil {
-			newMap[keyParts[0]] = make(Map)
+			newMap[keyParts[0]] = New()
 		}
-		newMap[keyParts[0]][keyParts[1]] = value
+		value := m.kv[key]
+		newMap[keyParts[0]].Set(keyParts[1], value)
 	}
 	return newMap
 }
@@ -248,14 +305,15 @@ func (m Map) FirstLevelOf() map[string]Map {
 //    "upload.protocol": "arduino",
 //    "upload.maximum_size": "32256",
 //  },
-func (m Map) SubTree(rootKey string) Map {
+func (m *Map) SubTree(rootKey string) *Map {
 	rootKey += "."
-	newMap := Map{}
-	for key, value := range m {
+	newMap := New()
+	for _, key := range m.o {
 		if !strings.HasPrefix(key, rootKey) {
 			continue
 		}
-		newMap[key[len(rootKey):]] = value
+		value := m.kv[key]
+		newMap.Set(key[len(rootKey):], value)
 	}
 	return newMap
 }
@@ -268,10 +326,10 @@ func (m Map) SubTree(rootKey string) Map {
 // Each marker is replaced by the corresponding value of the Map.
 // The values in the Map may contains other markers, they are evaluated
 // recursively up to 10 times.
-func (m Map) ExpandPropsInString(str string) string {
+func (m *Map) ExpandPropsInString(str string) string {
 	for i := 0; i < 10; i++ {
 		newStr := str
-		for key, value := range m {
+		for key, value := range m.kv {
 			newStr = strings.Replace(newStr, "{"+key+"}", value, -1)
 		}
 		if str == newStr {
@@ -284,54 +342,49 @@ func (m Map) ExpandPropsInString(str string) string {
 
 // Merge merges a Map into this one. Each key/value of the merged Maps replaces
 // the key/value present in the original Map.
-func (m Map) Merge(sources ...Map) Map {
+func (m *Map) Merge(sources ...*Map) *Map {
 	for _, source := range sources {
-		for key, value := range source {
-			m[key] = value
+		for _, key := range source.o {
+			value := source.kv[key]
+			m.Set(key, value)
 		}
 	}
 	return m
 }
 
 // Keys returns an array of the keys contained in the Map
-func (m Map) Keys() []string {
-	keys := make([]string, len(m))
-	i := 0
-	for key := range m {
-		keys[i] = key
-		i++
-	}
+func (m *Map) Keys() []string {
+	keys := make([]string, len(m.o))
+	copy(keys, m.o)
 	return keys
 }
 
 // Values returns an array of the values contained in the Map. Duplicated
 // values are repeated in the list accordingly.
 func (m Map) Values() []string {
-	values := make([]string, len(m))
-	i := 0
-	for _, value := range m {
-		values[i] = value
-		i++
+	values := make([]string, len(m.o))
+	for i, key := range m.o {
+		values[i] = m.kv[key]
 	}
 	return values
 }
 
 // Clone makes a copy of the Map
-func (m Map) Clone() Map {
-	clone := make(Map)
+func (m *Map) Clone() *Map {
+	clone := New()
 	clone.Merge(m)
 	return clone
 }
 
 // Equals returns true if the current Map contains the same key/value pairs of
-// the Map passed as argument.
-func (m Map) Equals(other Map) bool {
+// the Map passed as argument with the same order of insertion.
+func (m *Map) Equals(other *Map) bool {
 	return reflect.DeepEqual(m, other)
 }
 
 // MergeMapsOfProperties merge the map-of-Maps (obtained from the method FirstLevelOf()) into the
 // target map-of-Maps.
-func MergeMapsOfProperties(target map[string]Map, sources ...map[string]Map) map[string]Map {
+func MergeMapsOfProperties(target map[string]*Map, sources ...map[string]*Map) map[string]*Map {
 	for _, source := range sources {
 		for key, value := range source {
 			target[key] = value
@@ -348,15 +401,10 @@ func DeleteUnexpandedPropsFromString(str string) string {
 }
 
 // Dump returns a representation of the map in golang source format
-func (m Map) Dump() string {
+func (m *Map) Dump() string {
 	res := "properties.Map{\n"
-	keys := []string{}
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		res += fmt.Sprintf("  \"%s\": \"%s\",\n", strings.Replace(k, `"`, `\"`, -1), strings.Replace(m[k], `"`, `\"`, -1))
+	for _, k := range m.o {
+		res += fmt.Sprintf("  \"%s\": \"%s\",\n", strings.Replace(k, `"`, `\"`, -1), strings.Replace(m.Get(k), `"`, `\"`, -1))
 	}
 	res += "}"
 	return res

--- a/properties.go
+++ b/properties.go
@@ -99,8 +99,8 @@ func init() {
 	}
 }
 
-// New returns a new Map
-func New() *Map {
+// NewMap returns a new Map
+func NewMap() *Map {
 	return &Map{
 		kv: map[string]string{},
 		o:  []string{},
@@ -118,7 +118,7 @@ func Load(filepath string) (*Map, error) {
 	text = strings.Replace(text, "\r\n", "\n", -1)
 	text = strings.Replace(text, "\r", "\n", -1)
 
-	properties := New()
+	properties := NewMap()
 
 	for lineNum, line := range strings.Split(text, "\n") {
 		if err := properties.parseLine(line); err != nil {
@@ -137,7 +137,7 @@ func LoadFromPath(path *paths.Path) (*Map, error) {
 // LoadFromSlice reads a properties file from an array of string
 // and makes a Map out of it
 func LoadFromSlice(lines []string) (*Map, error) {
-	properties := New()
+	properties := NewMap()
 
 	for lineNum, line := range lines {
 		if err := properties.parseLine(line); err != nil {
@@ -180,7 +180,7 @@ func SafeLoadFromPath(path *paths.Path) (*Map, error) {
 func SafeLoad(filepath string) (*Map, error) {
 	_, err := os.Stat(filepath)
 	if os.IsNotExist(err) {
-		return New(), nil
+		return NewMap(), nil
 	}
 
 	properties, err := Load(filepath)
@@ -273,7 +273,7 @@ func (m *Map) FirstLevelOf() map[string]*Map {
 		}
 		keyParts := strings.SplitN(key, ".", 2)
 		if newMap[keyParts[0]] == nil {
-			newMap[keyParts[0]] = New()
+			newMap[keyParts[0]] = NewMap()
 		}
 		value := m.kv[key]
 		newMap[keyParts[0]].Set(keyParts[1], value)
@@ -307,7 +307,7 @@ func (m *Map) FirstLevelOf() map[string]*Map {
 //  },
 func (m *Map) SubTree(rootKey string) *Map {
 	rootKey += "."
-	newMap := New()
+	newMap := NewMap()
 	for _, key := range m.o {
 		if !strings.HasPrefix(key, rootKey) {
 			continue
@@ -371,7 +371,7 @@ func (m Map) Values() []string {
 
 // Clone makes a copy of the Map
 func (m *Map) Clone() *Map {
-	clone := New()
+	clone := NewMap()
 	clone.Merge(m)
 	return clone
 }

--- a/properties_test.go
+++ b/properties_test.go
@@ -44,12 +44,12 @@ func TestPropertiesBoardsTxt(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.Equal(t, "Processor", p["menu.cpu"])
-	require.Equal(t, "32256", p["ethernet.upload.maximum_size"])
-	require.Equal(t, "{build.usb_flags}", p["robotMotor.build.extra_flags"])
+	require.Equal(t, "Processor", p.Get("menu.cpu"))
+	require.Equal(t, "32256", p.Get("ethernet.upload.maximum_size"))
+	require.Equal(t, "{build.usb_flags}", p.Get("robotMotor.build.extra_flags"))
 
 	ethernet := p.SubTree("ethernet")
-	require.Equal(t, "Arduino Ethernet", ethernet["name"])
+	require.Equal(t, "Arduino Ethernet", ethernet.Get("name"))
 }
 
 func TestPropertiesTestTxt(t *testing.T) {
@@ -57,25 +57,25 @@ func TestPropertiesTestTxt(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.Equal(t, 4, len(p))
-	require.Equal(t, "value = 1", p["key"])
+	require.Equal(t, 4, p.Size())
+	require.Equal(t, "value = 1", p.Get("key"))
 
 	switch value := runtime.GOOS; value {
 	case "linux":
-		require.Equal(t, "is linux", p["which.os"])
+		require.Equal(t, "is linux", p.Get("which.os"))
 	case "windows":
-		require.Equal(t, "is windows", p["which.os"])
+		require.Equal(t, "is windows", p.Get("which.os"))
 	case "darwin":
-		require.Equal(t, "is macosx", p["which.os"])
+		require.Equal(t, "is macosx", p.Get("which.os"))
 	default:
 		require.FailNow(t, "unsupported OS")
 	}
 }
 
 func TestExpandPropsInString(t *testing.T) {
-	aMap := make(Map)
-	aMap["key1"] = "42"
-	aMap["key2"] = "{key1}"
+	aMap := New()
+	aMap.Set("key1", "42")
+	aMap.Set("key2", "{key1}")
 
 	str := "{key1} == {key2} == true"
 
@@ -84,9 +84,9 @@ func TestExpandPropsInString(t *testing.T) {
 }
 
 func TestExpandPropsInString2(t *testing.T) {
-	p := make(Map)
-	p["key2"] = "{key2}"
-	p["key1"] = "42"
+	p := New()
+	p.Set("key2", "{key2}")
+	p.Set("key1", "42")
 
 	str := "{key1} == {key2} == true"
 
@@ -95,9 +95,9 @@ func TestExpandPropsInString2(t *testing.T) {
 }
 
 func TestDeleteUnexpandedPropsFromString(t *testing.T) {
-	p := make(Map)
-	p["key1"] = "42"
-	p["key2"] = "{key1}"
+	p := New()
+	p.Set("key1", "42")
+	p.Set("key2", "{key1}")
 
 	str := "{key1} == {key2} == {key3} == true"
 
@@ -107,8 +107,8 @@ func TestDeleteUnexpandedPropsFromString(t *testing.T) {
 }
 
 func TestDeleteUnexpandedPropsFromString2(t *testing.T) {
-	p := make(Map)
-	p["key2"] = "42"
+	p := New()
+	p.Set("key2", "42")
 
 	str := "{key1} == {key2} == {key3} == true"
 
@@ -122,31 +122,28 @@ func TestPropertiesRedBeearLabBoardsTxt(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.Equal(t, 83, len(p))
-	require.Equal(t, "Blend", p["blend.name"])
-	require.Equal(t, "arduino:arduino", p["blend.build.core"])
-	require.Equal(t, "0x2404", p["blendmicro16.pid.0"])
+	require.Equal(t, 83, p.Size())
+	require.Equal(t, "Blend", p.Get("blend.name"))
+	require.Equal(t, "arduino:arduino", p.Get("blend.build.core"))
+	require.Equal(t, "0x2404", p.Get("blendmicro16.pid.0"))
 
 	ethernet := p.SubTree("blend")
-	require.Equal(t, "arduino:arduino", ethernet["build.core"])
+	require.Equal(t, "arduino:arduino", ethernet.Get("build.core"))
 }
 
 func TestSubTreeForMultipleDots(t *testing.T) {
-	p := Map{
-		"root.lev1.prop":  "hi",
-		"root.lev1.prop2": "how",
-		"root.lev1.prop3": "are",
-		"root.lev1.prop4": "you",
-		"root.lev1":       "A",
-	}
+	p := New()
+	p.Set("root.lev1.prop", "hi")
+	p.Set("root.lev1.prop2", "how")
+	p.Set("root.lev1.prop3", "are")
+	p.Set("root.lev1.prop4", "you")
+	p.Set("root.lev1", "A")
 
 	lev1 := p.SubTree("root.lev1")
-	require.EqualValues(t, Map{
-		"prop4": "you",
-		"prop":  "hi",
-		"prop2": "how",
-		"prop3": "are",
-	}, lev1)
+	require.Equal(t, "you", lev1.Get("prop4"))
+	require.Equal(t, "hi", lev1.Get("prop"))
+	require.Equal(t, "how", lev1.Get("prop2"))
+	require.Equal(t, "are", lev1.Get("prop3"))
 }
 
 func TestPropertiesBroken(t *testing.T) {
@@ -156,11 +153,10 @@ func TestPropertiesBroken(t *testing.T) {
 }
 
 func TestGetSetBoolean(t *testing.T) {
-	m := Map{
-		"a": "true",
-		"b": "false",
-		"c": "hello",
-	}
+	m := New()
+	m.Set("a", "true")
+	m.Set("b", "false")
+	m.Set("c", "hello")
 	m.SetBoolean("e", true)
 	m.SetBoolean("f", false)
 
@@ -170,17 +166,16 @@ func TestGetSetBoolean(t *testing.T) {
 	require.False(t, m.GetBoolean("d"))
 	require.True(t, m.GetBoolean("e"))
 	require.False(t, m.GetBoolean("f"))
-	require.Equal(t, "true", m["e"])
-	require.Equal(t, "false", m["f"])
+	require.Equal(t, "true", m.Get("e"))
+	require.Equal(t, "false", m.Get("f"))
 }
 
 func TestKeysMethod(t *testing.T) {
-	m := Map{
-		"k1":    "value",
-		"k2":    "othervalue",
-		"k3.k4": "anothevalue",
-		"k5":    "value",
-	}
+	m := New()
+	m.Set("k1", "value")
+	m.Set("k2", "othervalue")
+	m.Set("k3.k4", "anothevalue")
+	m.Set("k5", "value")
 
 	k := m.Keys()
 	sort.Strings(k)

--- a/properties_test.go
+++ b/properties_test.go
@@ -73,7 +73,7 @@ func TestPropertiesTestTxt(t *testing.T) {
 }
 
 func TestExpandPropsInString(t *testing.T) {
-	aMap := New()
+	aMap := NewMap()
 	aMap.Set("key1", "42")
 	aMap.Set("key2", "{key1}")
 
@@ -84,7 +84,7 @@ func TestExpandPropsInString(t *testing.T) {
 }
 
 func TestExpandPropsInString2(t *testing.T) {
-	p := New()
+	p := NewMap()
 	p.Set("key2", "{key2}")
 	p.Set("key1", "42")
 
@@ -95,7 +95,7 @@ func TestExpandPropsInString2(t *testing.T) {
 }
 
 func TestDeleteUnexpandedPropsFromString(t *testing.T) {
-	p := New()
+	p := NewMap()
 	p.Set("key1", "42")
 	p.Set("key2", "{key1}")
 
@@ -107,7 +107,7 @@ func TestDeleteUnexpandedPropsFromString(t *testing.T) {
 }
 
 func TestDeleteUnexpandedPropsFromString2(t *testing.T) {
-	p := New()
+	p := NewMap()
 	p.Set("key2", "42")
 
 	str := "{key1} == {key2} == {key3} == true"
@@ -132,7 +132,7 @@ func TestPropertiesRedBeearLabBoardsTxt(t *testing.T) {
 }
 
 func TestSubTreeForMultipleDots(t *testing.T) {
-	p := New()
+	p := NewMap()
 	p.Set("root.lev1.prop", "hi")
 	p.Set("root.lev1.prop2", "how")
 	p.Set("root.lev1.prop3", "are")
@@ -153,7 +153,7 @@ func TestPropertiesBroken(t *testing.T) {
 }
 
 func TestGetSetBoolean(t *testing.T) {
-	m := New()
+	m := NewMap()
 	m.Set("a", "true")
 	m.Set("b", "false")
 	m.Set("c", "hello")
@@ -171,7 +171,7 @@ func TestGetSetBoolean(t *testing.T) {
 }
 
 func TestKeysMethod(t *testing.T) {
-	m := New()
+	m := NewMap()
 	m.Set("k1", "value")
 	m.Set("k2", "othervalue")
 	m.Set("k3.k4", "anothevalue")


### PR DESCRIPTION
This is required on `arduino-cli` and is a breaking change on the previous API.

1. It is no more possible to directly get/set on the map
2. It is no more possible to range on key/values if you need ordered pairs

```go
mymap := properties.Map{}
val, ok := mymap[x]
val := mymap[x]
mymap[k] = v
for k, v := range mymap {
    ...
}
```

must be changed to:
```go
mymap := properties.NewMap()
val, ok := mymap.GetOk(x)
val := mymap.Get(x)
mymap.Set(k, v)
for _, k := range mymap.Keys() {
    v := mymap.Get(k)
    ...
}
```
